### PR TITLE
Support letter-spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Support letter-spacing
+
 ## 1.0.2 - 2025-03-11
 
 - Support flex-self

--- a/Fun.Css.Tests/BasicTests.fs
+++ b/Fun.Css.Tests/BasicTests.fs
@@ -45,3 +45,14 @@ let ``Flex should work`` () =
         flexGrow 1
     }
     Assert.Equal("display: flex; flex: 1; flex: 1 1; flex: 1 10%; flex: 1 1 10%; flex-grow: 1; ", actual)
+
+[<Fact>]
+let ``letter-spacing should work`` () =
+    let actual = style {
+        letterSpacing 2
+        letterSpacing "0.08em"
+        letterSpacingNormal
+        letterSpacingInitial
+        letterSpacingInheritFromParent
+    }
+    Assert.Equal("letter-spacing: 2px; letter-spacing: 0.08em; letter-spacing: normal; letter-spacing: initial; letter-spacing: inherit; ", actual)

--- a/Fun.Css/CssBuilder.fs
+++ b/Fun.Css/CssBuilder.fs
@@ -457,6 +457,22 @@ type CssBuilder() =
     [<CustomOperation("fontWeightInheritFromParent")>]
     member inline _.fontWeightInheritFromParent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("font-weight", "inherit")
 
+    /// Sets the spacing between text characters.
+    [<CustomOperation("letterSpacing")>]
+    member inline _.letterSpacing([<InlineIfLambda>] comb: CombineKeyValue, value: int) = comb &&& mkPxWithKV ("letter-spacing", value)
+    /// Sets the spacing between text characters.
+    [<CustomOperation("letterSpacing")>]
+    member inline _.letterSpacing([<InlineIfLambda>] comb: CombineKeyValue, value: string) = comb &>> ("letter-spacing", value)
+    /// Specifies the default letter spacing for the current font.
+    [<CustomOperation("letterSpacingNormal")>]
+    member inline _.letterSpacingNormal([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("letter-spacing", "normal")
+    /// Sets this property to its default value.
+    [<CustomOperation("letterSpacingInitial")>]
+    member inline _.letterSpacingInitial([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("letter-spacing", "initial")
+    /// Inherits this property from its parent element.
+    [<CustomOperation("letterSpacingInheritFromParent")>]
+    member inline _.letterSpacingInheritFromParent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("letter-spacing", "inherit")
+
     /// The browser displays a normal font style. This is defaut.
     [<CustomOperation("fontStyleNormal")>]
     member inline _.fontStyleNormal([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("font-style", "normal")


### PR DESCRIPTION
Hi! Adds `letterSpacing` overloads, which were missing from the typography property set.

## Why

While building a Fun.Blazor project with CSS-variable design tokens (passing `var(--tracking-tight)` strings into style blocks), `letterSpacing` was the only typography property without a typed binding — I had to fall back to `custom "letter-spacing" value`. Every other typography property (`fontSize`, `fontWeight`, `lineHeight`, `fontStretch`, `textTransform`, etc.) has typed coverage.

## What's added

- `letterSpacing(int)` — pixel value
- `letterSpacing(string)` — any CSS length, including `var(...)` for CSS variables
- `letterSpacingNormal` — keyword
- `letterSpacingInitial` — keyword
- `letterSpacingInheritFromParent` — keyword

Mirrors the `fontSize` int/string overload pattern. Placed in `CssBuilder.fs` right after the `fontWeight` block, since they're sibling typography properties.

## Verification

- `dotnet build -c Release` — green, 0 warnings, 0 errors
- `dotnet test` — 3/3 passing (the new `letter-spacing should work` test asserts all 5 ops produce the expected CSS)