### PR TITLE
Add fontWeight(string) overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add `fontWeight(string)` overload for CSS-variable / keyword string values
+
 ## 1.0.2 - 2025-03-11
 
 - Support flex-self

--- a/Fun.Css.Tests/BasicTests.fs
+++ b/Fun.Css.Tests/BasicTests.fs
@@ -45,3 +45,11 @@ let ``Flex should work`` () =
         flexGrow 1
     }
     Assert.Equal("display: flex; flex: 1; flex: 1 1; flex: 1 10%; flex: 1 1 10%; flex-grow: 1; ", actual)
+
+[<Fact>]
+let ``font-weight string should work`` () =
+    let actual = style {
+        fontWeight "bold"
+        fontWeight "var(--typography-strong-font-weight)"
+    }
+    Assert.Equal("font-weight: bold; font-weight: var(--typography-strong-font-weight); ", actual)

--- a/Fun.Css/CssBuilder.fs
+++ b/Fun.Css/CssBuilder.fs
@@ -438,6 +438,9 @@ type CssBuilder() =
     /// Possible values are [100, 200, 300, 400, 500, 600, 700, 800, 900]
     [<CustomOperation("fontWeight")>]
     member inline _.fontWeight([<InlineIfLambda>] comb: CombineKeyValue, weight: int) = comb &&& mkWithKV ("font-weight", weight)
+    /// Defines font weight using a CSS string value (e.g. "bold", "var(--font-weight-strong)").
+    [<CustomOperation("fontWeight")>]
+    member inline _.fontWeight([<InlineIfLambda>] comb: CombineKeyValue, weight: string) = comb &>> ("font-weight", weight)
     /// Defines normal characters. This is default.
     [<CustomOperation("fontWeightNormal")>]
     member inline _.fontWeightNormal([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("font-weight", "normal")


### PR DESCRIPTION
Hi! Adds a `(string)` overload to `fontWeight` so CSS string values (including `var(...)`) can be passed without falling back to `custom "font-weight" value`.

## Why

`fontWeight` currently has only `(int)` for numeric weights and typed unit ops (`fontWeightNormal`, `fontWeightBold`, `fontWeightLighter`, etc.) for keywords. The `(string)` overload is missing — so passing a CSS variable like `var(--typography-strong-font-weight)` from a design-token binding doesn't typecheck.

`fontSize` already has both `(int)` and `(string)` overloads; this PR brings `fontWeight` in line with that pattern.

## What's added

```fsharp
/// Defines font weight using a CSS string value (e.g. "bold", "var(--font-weight-strong)").
[<CustomOperation("fontWeight")>]
member inline _.fontWeight([<InlineIfLambda>] comb: CombineKeyValue, weight: string) = comb &>> ("font-weight", weight)
```

Placed immediately after the existing `fontWeight(int)` overload at `CssBuilder.fs:440`. The existing `(int)` overload and typed unit ops are unchanged.

## Verification

- `dotnet build -c Release` — green, 0 warnings, 0 errors
- `dotnet test` — 3/3 passing (new `font-weight string should work` test asserts the keyword and `var(...)` cases)