### PR TITLE
Fix CSS property emission bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix several CSS property emission bugs: `maxHeightMaxContent`/`maxHeightMinContent` now emit `max-height`, `minHeightMaxContent`/`minHeightMinContent` now emit `min-height`, `flexDirectionInitial`/`flexDirectionInheritFromParent` now emit `flex-direction`, `outlineOffset` now emits `outline-offset`, and `justifyItemsStrench`/`justifySelfStrench` now emit the valid CSS value `stretch`
+
 ## 1.0.2 - 2025-03-11
 
 - Support flex-self

--- a/Fun.Css.Tests/BasicTests.fs
+++ b/Fun.Css.Tests/BasicTests.fs
@@ -45,3 +45,37 @@ let ``Flex should work`` () =
         flexGrow 1
     }
     Assert.Equal("display: flex; flex: 1; flex: 1 1; flex: 1 10%; flex: 1 1 10%; flex-grow: 1; ", actual)
+
+[<Fact>]
+let ``max-height and min-height with intrinsic sizing should emit the right property`` () =
+    let actual = style {
+        maxHeightMaxContent
+        maxHeightMinContent
+        minHeightMaxContent
+        minHeightMinContent
+    }
+    Assert.Equal("max-height: max-content; max-height: min-content; min-height: max-content; min-height: min-content; ", actual)
+
+[<Fact>]
+let ``flex-direction initial and inherit should emit flex-direction`` () =
+    let actual = style {
+        flexDirectionInitial
+        flexDirectionInheritFromParent
+    }
+    Assert.Equal("flex-direction: initial; flex-direction: inherit; ", actual)
+
+[<Fact>]
+let ``outline-offset should emit outline-offset`` () =
+    let actual = style {
+        outlineOffset 4
+        outlineOffset "1rem"
+    }
+    Assert.Equal("outline-offset: 4px; outline-offset: 1rem; ", actual)
+
+[<Fact>]
+let ``justify-items and justify-self Strench should emit the valid stretch value`` () =
+    let actual = style {
+        justifyItemsStrench
+        justifySelfStrench
+    }
+    Assert.Equal("justify-items: stretch; justify-self: stretch; ", actual)

--- a/Fun.Css/CssBuilder.fs
+++ b/Fun.Css/CssBuilder.fs
@@ -178,10 +178,10 @@ type CssBuilder() =
     member inline _.maxHeightInitial([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("max-height", "initial")
     /// The intrinsic preferred height.
     [<CustomOperation("maxHeightMaxContent")>]
-    member inline _.maxHeightMaxContent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("height", "max-content")
+    member inline _.maxHeightMaxContent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("max-height", "max-content")
     /// The intrinsic minimum height.
     [<CustomOperation("maxHeightMinContent")>]
-    member inline _.maxHeightMinContent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("height", "min-content")
+    member inline _.maxHeightMinContent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("max-height", "min-content")
 
     [<CustomOperation("minHeight")>]
     member inline _.minHeight([<InlineIfLambda>] comb: CombineKeyValue, value: int) = comb &&& mkPxWithKV ("min-height", value)
@@ -195,10 +195,10 @@ type CssBuilder() =
     member inline _.minHeightInitial([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("min-height", "initial")
     /// The intrinsic preferred height.
     [<CustomOperation("minHeightMaxContent")>]
-    member inline _.minHeightMaxContent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("height", "max-content")
+    member inline _.minHeightMaxContent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("min-height", "max-content")
     /// The intrinsic minimum height.
     [<CustomOperation("minHeightMinContent")>]
-    member inline _.minHeightMinContent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("height", "min-content")
+    member inline _.minHeightMinContent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("min-height", "min-content")
 
     /// The browser determines the justification algorithm
     [<CustomOperation("textJustifyAuto")>]
@@ -375,10 +375,10 @@ type CssBuilder() =
     member inline _.flexDirectionColumnReverse([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("flex-direction", "column-reverse")
     /// Sets this property to its default value.
     [<CustomOperation("flexDirectionInitial")>]
-    member inline _.flexDirectionInitial([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("flex-basis", "initial")
+    member inline _.flexDirectionInitial([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("flex-direction", "initial")
     /// Inherits this property from its parent element.
     [<CustomOperation("flexDirectionInheritFromParent")>]
-    member inline _.flexDirectionInheritFromParent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("flex-basis", "inherit")
+    member inline _.flexDirectionInheritFromParent([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("flex-direction", "inherit")
 
     /// Default value. Specifies that the flexible items will not wrap.
     [<CustomOperation("flexWrapNowrap")>]
@@ -658,7 +658,7 @@ type CssBuilder() =
     member inline _.justifyItemsBaseline([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("justify-items", "baseline")
     ///If the combined size of the items is less than the size of the alignment container, any auto-sized items have their size increased equally (not proportionally), while still respecting the constraints imposed by max-height/max-width (or equivalent functionality), so that the combined size exactly fills the alignment container.
     [<CustomOperation("justifyItemsStrench")>]
-    member inline _.justifyItemsStrench([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("justify-items", "strench")
+    member inline _.justifyItemsStrench([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("justify-items", "stretch")
     /// In the case of anchor-positioned elements, aligns the items to the center of the associated anchor element in the inline direction. See Centering on the anchor using anchor-center.
     [<CustomOperation("justifyItemsAnchorCenter")>]
     member inline _.justifyItemsAnchorCenter([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("justify-items", "anchor-center")
@@ -706,7 +706,7 @@ type CssBuilder() =
     member inline _.justifySelfBaseline([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("justify-self", "baseline")
     /// If the combined size of the items is less than the size of the alignment container, any auto-sized items have their size increased equally (not proportionally), while still respecting the constraints imposed by max-height/max-width (or equivalent functionality), so that the combined size exactly fills the alignment container.
     [<CustomOperation("justifySelfStrench")>]
-    member inline _.justifySelfStrench([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("justify-self", "strench")
+    member inline _.justifySelfStrench([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("justify-self", "stretch")
     /// In the case of anchor-positioned elements, aligns the item to the center of the associated anchor element in the inline direction. See Centering on the anchor using anchor-center.
     [<CustomOperation("justifySelfAnchorCenter")>]
     member inline _.justifySelfAnchorCenter([<InlineIfLambda>] comb: CombineKeyValue) = comb &>> ("justify-self", "anchor-center")
@@ -3043,7 +3043,7 @@ type CssBuilder() =
     ///  - An outline may be non-rectangular
     ///
     [<CustomOperation("outlineOffset")>]
-    member inline _.outlineOffset([<InlineIfLambda>] comb: CombineKeyValue, offset: int) = comb &&& mkPxWithKV ("outline-width", offset)
+    member inline _.outlineOffset([<InlineIfLambda>] comb: CombineKeyValue, offset: int) = comb &&& mkPxWithKV ("outline-offset", offset)
 
     /// The outline-offset property adds space between an outline and the edge or border of an element.
     ///
@@ -3056,7 +3056,7 @@ type CssBuilder() =
     ///  - An outline may be non-rectangular
     ///
     [<CustomOperation("outlineOffset")>]
-    member inline _.outlineOffset([<InlineIfLambda>] comb: CombineKeyValue, offset: string) = comb &>> ("outline-width", offset)
+    member inline _.outlineOffset([<InlineIfLambda>] comb: CombineKeyValue, offset: string) = comb &>> ("outline-offset", offset)
 
     /// An outline is a line that is drawn around elements (outside the borders) to make the element "stand out".
     ///


### PR DESCRIPTION
Hi! Fixes a handful of silent runtime bugs where the F# member name implies one CSS property but the implementation emits a different one (or an invalid CSS value).

## Bugs fixed

| F# member | Was emitting | Now emits |
|---|---|---|
| `maxHeightMaxContent` | `height: max-content` | `max-height: max-content` |
| `maxHeightMinContent` | `height: min-content` | `max-height: min-content` |
| `minHeightMaxContent` | `height: max-content` | `min-height: max-content` |
| `minHeightMinContent` | `height: min-content` | `min-height: min-content` |
| `flexDirectionInitial` | `flex-basis: initial` | `flex-direction: initial` |
| `flexDirectionInheritFromParent` | `flex-basis: inherit` | `flex-direction: inherit` |
| `outlineOffset(int)` | `outline-width: <px>` | `outline-offset: <px>` |
| `outlineOffset(string)` | `outline-width: <val>` | `outline-offset: <val>` |
| `justifyItemsStrench` | `justify-items: strench` (invalid) | `justify-items: stretch` |
| `justifySelfStrench` | `justify-self: strench` (invalid) | `justify-self: stretch` |

All look like copy-paste from neighbouring blocks. Users calling these today get a no-op (browser silently ignores the wrong property or invalid CSS value).

## Out of scope

- **Renaming `justifyItemsStrench` → `justifyItemsStretch`** (and `justifySelf...` same): this is a breaking change to the F# API surface. Probably worth a separate issue to discuss whether to rename, deprecate-and-add, or leave the name typo alone. This PR fixes only the runtime behaviour.
- **Other API name typos** (e.g., `backgroundBlendModeCollorDodge` with the wrong `Collor` spelling): same reasoning — name-typo discussion belongs in a separate issue.

## Verification

- `dotnet build -c Release` — green, 0 warnings, 0 errors
- `dotnet test` — 6/6 passing (4 new tests added, one per logical fix group)